### PR TITLE
Fix scraping of event dates and times

### DIFF
--- a/src/event-details/find.js
+++ b/src/event-details/find.js
@@ -12,7 +12,7 @@ const findEventType = eventPage => {
     return JSON.parse(jsonLdString
             .replace(/\n/g,"")
     )['@type'];
-}
+};
 
 const findEventLinks = htmlDoc => {
     const $ = cheerio.load(htmlDoc);
@@ -31,43 +31,46 @@ const findEventLinks = htmlDoc => {
 const findArtists = eventPage => {
     const $ = cheerio.load(eventPage);
     return $('.event-information').find('h1').text();
-}
+};
 
 const findCityAndVenue = eventPage => {
     const $ = cheerio.load(eventPage);
     return $('.venue-details').find('h2').text();
-}
+};
 
-const findDate = eventPage => {
+const findDateAndTime = eventPage => {
     const $ = cheerio.load(eventPage);
-    return $('.venue-details').find('h4').text();
-}
+    return $('.doorTime')
+        .html()
+        .split('<br>')
+        .map((html) => html.trim());
+};
 
 const findPrice = eventPage => {
     const $ = cheerio.load(eventPage);
     return $('.BuyBox').find('strong').text();
-}
+};
 
 const findEventDetails = eventPage => {
     const artists = findArtists(eventPage);
     const cityAndVenue = findCityAndVenue(eventPage);
-    const date = findDate(eventPage);
+    const dateAndTime = findDateAndTime(eventPage);
     const price = findPrice(eventPage);
 
     return {
         artists,
         cityAndVenue,
-        date,
+        dateAndTime,
         price,
     };
-}
+};
 
 module.exports = {
     findEventType,
     findEventLinks,
     findArtists,
     findCityAndVenue,
-    findDate,
+    findDateAndTime,
     findPrice,
     findEventDetails,
 }

--- a/src/event-details/format.js
+++ b/src/event-details/format.js
@@ -32,14 +32,16 @@ const formatVenue = cityAndVenue => {
   return 'WARNING: CHECK FORMATTING';
 };
 
+const formatDateAndTime = dateAndTime => dateAndTime.join('. ');
+
 const formatEventDetails = unformattedDetails => {
-  const {artists, cityAndVenue, date, price } = unformattedDetails;
+  const {artists, cityAndVenue, dateAndTime, price } = unformattedDetails;
 
   return {
     artists: formatArtists(artists),
     city: formatCity(cityAndVenue),
     venue: formatVenue(cityAndVenue),
-    date,
+    date: formatDateAndTime(dateAndTime),
     price,
   };
 };
@@ -52,4 +54,5 @@ module.exports = {
   formatArtists,
   formatEventDetails,
   formatHeaders,
+  formatDateAndTime,
 };

--- a/test/event-details/fetch.spec.js
+++ b/test/event-details/fetch.spec.js
@@ -65,13 +65,13 @@ describe('fetch event details', () => {
         it('returns event details from an event page', async () => {
             // given
             const hostName = 'https://www.wegottickets.com';
-            const path = '/event/429096';
+            const path = '/event/461540';
 
             const expectedDetails = {
-                artists: 'THE DREAMERS',
-                cityAndVenue: 'DARLINGTON: Harrowgate Club & Institute Ltd',
-                date: 'FRI 28TH SEP, 2018 6:30pm',
-                price: '£9.90',
+                artists: 'PUPPY',
+                cityAndVenue: 'LEEDS: The Brudenell Social Club',
+                dateAndTime: ['Wed 24th Apr, 2019', 'Door time: 7:30pm'],
+                price: '£11.00',
             };
 
             nock(hostName)

--- a/test/event-details/find.spec.js
+++ b/test/event-details/find.spec.js
@@ -5,7 +5,7 @@ const findEventType = require('../../src/event-details/find').findEventType;
 const findEventLinks = require('../../src/event-details/find').findEventLinks;
 const findCityAndVenue = require('../../src/event-details/find').findCityAndVenue;
 const findArtists = require('../../src/event-details/find').findArtists;
-const findDate = require('../../src/event-details/find').findDate;
+const findDateAndTime = require('../../src/event-details/find').findDateAndTime;
 const findPrice = require('../../src/event-details/find').findPrice;
 const findEventDetails = require('../../src/event-details/find').findEventDetails;
 
@@ -14,7 +14,6 @@ const musicEventPage = require('../helpers/music-event-page.spec').musicEventPag
 const noTypeEventPage = require('../helpers/no-type-event-page.spec').noTypeEventPage;
 
 describe('find event information', () => {
-    
     describe('#findEventType', () => {
         describe('when event type is present', () => {
             it('finds the event type', () => {
@@ -59,7 +58,7 @@ describe('find event information', () => {
 
     describe('#findArtists', () => {
         it('finds artists from HTML', () => {
-            const expectedArtists = 'THE DREAMERS';
+            const expectedArtists = 'PUPPY';
 
             const artists = findArtists(musicEventPage);
             expect(artists).to.equal(expectedArtists);
@@ -68,25 +67,25 @@ describe('find event information', () => {
 
     describe('#findCityAndVenue', () => {
         it('finds city and venue from HTML', () => {
-            const expectedCityAndVenue = 'DARLINGTON: Harrowgate Club & Institute Ltd';
+            const expectedCityAndVenue = 'LEEDS: The Brudenell Social Club';
 
             const cityAndVenue = findCityAndVenue(musicEventPage);
             expect(cityAndVenue).to.equal(expectedCityAndVenue);
         });
     });
 
-    describe('#findDate', () => {
-        it('finds date and time from HTML', () => {
-            const expectedDateAndTime = 'FRI 28TH SEP, 2018 6:30pm';
+    describe('#findDateAndTime', () => {
+        it('returns date and time array from HTML', () => {
+            const expectedDateAndTime = ['Wed 24th Apr, 2019', 'Door time: 7:30pm'];
 
-            const dateAndTime = findDate(musicEventPage);
-            expect(dateAndTime).to.equal(expectedDateAndTime);
+            const dateAndTime = findDateAndTime(musicEventPage);
+            expect(dateAndTime).to.eql(expectedDateAndTime);
         });
     });
 
     describe('#findPrice', () => {
         it('finds price from HTML', () => {
-            const expectedPrice = '£9.90';
+            const expectedPrice = '£11.00';
 
             const price = findPrice(musicEventPage);
             expect(price).to.equal(expectedPrice);
@@ -96,10 +95,10 @@ describe('find event information', () => {
     describe('#findEventDetails', () => {
         it('returns unformatted event details from HTML as JSON', () => {
             const expectedDetails = {
-                'artists': 'THE DREAMERS',
-                'cityAndVenue': 'DARLINGTON: Harrowgate Club & Institute Ltd',
-                'date': 'FRI 28TH SEP, 2018 6:30pm',
-                'price': '£9.90',
+                'artists': 'PUPPY',
+                'cityAndVenue': 'LEEDS: The Brudenell Social Club',
+                'dateAndTime': ['Wed 24th Apr, 2019', 'Door time: 7:30pm'],
+                'price': '£11.00',
             };
             
             const details = findEventDetails(musicEventPage);

--- a/test/event-details/format.spec.js
+++ b/test/event-details/format.spec.js
@@ -6,6 +6,7 @@ const formatVenue = require('../../src/event-details/format').formatVenue;
 const formatArtists = require('../../src/event-details/format').formatArtists;
 const formatEventDetails = require('../../src/event-details/format').formatEventDetails;
 const formatHeaders = require('../../src/event-details/format').formatHeaders;
+const formatDateAndTime = require('../../src/event-details/format').formatDateAndTime;
 
 describe('format headers', () => {
   describe('#formatHeaders', () => {
@@ -116,22 +117,31 @@ describe('format event details', () => {
     });
   });
 
+  describe('#formatDateAndTime', () => {
+    it('returns correctly formatted date and time', () => {
+      const dateAndTime = ['Wed 24th Apr, 2019', 'Door time: 7:30pm'];
+      const expectedDateAndTime = 'Wed 24th Apr, 2019. Door time: 7:30pm'
+
+      expect(formatDateAndTime(dateAndTime)).to.equal(expectedDateAndTime);
+    });
+  });
+
   describe('#formatEventDetails', () => {
     it('correctly formats unformatted event details', () => {
       // given
       const unformattedDetails = {
-        artists: 'THE DREAMERS',
-        cityAndVenue: 'DARLINGTON: Harrowgate Club & Institute Ltd',
-        date: 'FRI 28TH SEP, 2018 6:30pm',
-        price: '£9.90',
+        artists: 'PUPPY',
+        cityAndVenue: 'LEEDS: The Brudenell Social Club',
+        dateAndTime: ['Wed 24th Apr, 2019', 'Door time: 7:30pm'],
+        price: '£11.00',
       };
 
       const formattedDetails = {
-        artists: 'The Dreamers',
-        city: 'Darlington',
-        venue: 'Harrowgate Club & Institute Ltd',
-        date: 'FRI 28TH SEP, 2018 6:30pm',
-        price: '£9.90',
+        artists: 'Puppy',
+        city: 'Leeds',
+        venue: 'The Brudenell Social Club',
+        date: 'Wed 24th Apr, 2019. Door time: 7:30pm',
+        price: '£11.00',
       };
 
       // when

--- a/test/helpers/music-event-page.spec.js
+++ b/test/helpers/music-event-page.spec.js
@@ -4,20 +4,20 @@ module.exports = {
         <html xmlns="http://www.w3.org/1999/xhtml">
         <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# fbwegottickets: http://ogp.me/ns/fb/fbwegottickets#">
         <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15" />
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>WeGotTickets | Simple, honest ticketing | THE DREAMERS</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <title>WeGotTickets | Simple, honest ticketing | PUPPY</title>
         <meta name="Description" content="Buy tickets for music, comedy, theatre, film, festivals and much more - with the best service in UK ticketing" />
-
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/myfonts.webkit.css">
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/pocketgrid.min.css">
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/normalize.css">
+        
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/myfonts.webkit.css"/>
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/pocketgrid.min.css"/>
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/normalize.css"/>
         <link rel="stylesheet" type="text/css" media="only screen and (max-width: 768px)" href="https://www.wegottickets.com/css/menu.css"/>
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/skin.css?updated=2018-09-19">
-
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/categories.css">
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/typography.css">
-        <link rel="stylesheet" type="text/css" href="/rebrand/css/slick.css">
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/skin.css?updated=2019-03-18"/>
+        
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/categories.css"/>
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/typography.css?updated=2018-12-13"/>
+        <link rel="stylesheet" type="text/css" href="/rebrand/css/slick.css"/>
         <!--[if IE]>
         <link rel="stylesheet" type="text/css" href="/css/b/ielt8fix.css" />
         <![endif]-->
@@ -27,647 +27,685 @@ module.exports = {
         <!--[if IE 7]>
         <link rel="stylesheet" type="text/css" href="/css/b/ie7fix.css" />
         <![endif]-->
-
+        
         <?php // http://realfavicongenerator.net ?>
-        <link rel="apple-touch-icon" sizes="57x57" href="/rebrand/images/icons/favicons/apple-touch-icon-57x57.png">
-        <link rel="apple-touch-icon" sizes="60x60" href="/rebrand/images/icons/favicons/apple-touch-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72" href="/rebrand/images/icons/favicons/apple-touch-icon-72x72.png">
-        <link rel="apple-touch-icon" sizes="76x76" href="/rebrand/images/icons/favicons/apple-touch-icon-76x76.png">
-        <link rel="apple-touch-icon" sizes="114x114" href="/rebrand/images/icons/favicons/apple-touch-icon-114x114.png">
-        <link rel="apple-touch-icon" sizes="120x120" href="/rebrand/images/icons/favicons/apple-touch-icon-120x120.png">
-        <link rel="apple-touch-icon" sizes="144x144" href="/rebrand/images/icons/favicons/apple-touch-icon-144x144.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/rebrand/images/icons/favicons/apple-touch-icon-152x152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/rebrand/images/icons/favicons/apple-touch-icon-180x180.png">
-        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-32x32.png" sizes="32x32">
-        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-194x194.png" sizes="194x194">
-        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-96x96.png" sizes="96x96">
-        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/android-chrome-192x192.png" sizes="192x192">
-        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-16x16.png" sizes="16x16">
-        <link rel="manifest" href="/rebrand/images/icons/favicons/manifest.json">
-        <link rel="mask-icon" href="/rebrand/images/icons/favicons/safari-pinned-tab.svg" color="#43a6cf">
-        <link rel="shortcut icon" href="/rebrand/images/icons/favicons/favicon.ico">
-        <meta name="apple-mobile-web-app-title" content="WeGotTickets">
-        <meta name="application-name" content="WeGotTickets">
-        <meta name="msapplication-TileColor" content="#ffffff">
-        <meta name="msapplication-TileImage" content="/rebrand/images/icons/favicons/mstile-144x144.png">
-        <meta name="msapplication-config" content="/rebrand/images/icons/favicons/browserconfig.xml">
-        <meta name="theme-color" content="#43a6cf">
-
+        <link rel="apple-touch-icon" sizes="57x57" href="/rebrand/images/icons/favicons/apple-touch-icon-57x57.png"/>
+        <link rel="apple-touch-icon" sizes="60x60" href="/rebrand/images/icons/favicons/apple-touch-icon-60x60.png"/>
+        <link rel="apple-touch-icon" sizes="72x72" href="/rebrand/images/icons/favicons/apple-touch-icon-72x72.png"/>
+        <link rel="apple-touch-icon" sizes="76x76" href="/rebrand/images/icons/favicons/apple-touch-icon-76x76.png"/>
+        <link rel="apple-touch-icon" sizes="114x114" href="/rebrand/images/icons/favicons/apple-touch-icon-114x114.png"/>
+        <link rel="apple-touch-icon" sizes="120x120" href="/rebrand/images/icons/favicons/apple-touch-icon-120x120.png"/>
+        <link rel="apple-touch-icon" sizes="144x144" href="/rebrand/images/icons/favicons/apple-touch-icon-144x144.png"/>
+        <link rel="apple-touch-icon" sizes="152x152" href="/rebrand/images/icons/favicons/apple-touch-icon-152x152.png"/>
+        <link rel="apple-touch-icon" sizes="180x180" href="/rebrand/images/icons/favicons/apple-touch-icon-180x180.png"/>
+        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-32x32.png" sizes="32x32"/>
+        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-194x194.png" sizes="194x194"/>
+        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-96x96.png" sizes="96x96"/>
+        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/android-chrome-192x192.png" sizes="192x192"/>
+        <link rel="icon" type="image/png" href="/rebrand/images/icons/favicons/favicon-16x16.png" sizes="16x16"/>
+        <link rel="manifest" href="/rebrand/images/icons/favicons/manifest.json"/>
+        <link rel="mask-icon" href="/rebrand/images/icons/favicons/safari-pinned-tab.svg" />
+        <link rel="shortcut icon" href="/rebrand/images/icons/favicons/favicon.ico"/>
+        <meta name="apple-mobile-web-app-title" content="WeGotTickets"/>
+        <meta name="application-name" content="WeGotTickets"/>
+        <meta name="msapplication-TileColor" content="#ffffff"/>
+        <meta name="msapplication-TileImage" content="/rebrand/images/icons/favicons/mstile-144x144.png"/>
+        <meta name="msapplication-config" content="/rebrand/images/icons/favicons/browserconfig.xml"/>
+        <meta name="theme-color" content="#43a6cf"/>
+        
         <!-- Sharing -->
         <meta property="fb:app_id" content="835221453272159" />
-        <meta property="og:url" content="https://www.wegottickets.com/event/429096" />
+        <meta property="og:url" content="https://www.wegottickets.com/event/461540" />
         <meta property="og:type" content="fbwegottickets:event" />
         <meta property="og:site_name" content="WeGotTickets" />
-        <meta property="og:title" content="The Dreamers" />
-        <meta property="og:description" content="Formerly �Freddie and The Dreamers.� The Dreamers remain one of the best known named bands 
-        on the sixties music circuit. Changes to personnel over the past 50 years were of course inevitable but two members� 
-        Alan Mosca and Bryan Byng remain in the band today, they have been in the band as 'Freddie and The Dreamers'
-        &amp;#8203;and then 'The Dreamers' for over 40 years.
-        Alan and Bryan are joined by The Temple Brothers, Steve and Colin who in their own right are seasoned professionals having
-        toured extensively with their Everly Brothers tribute show and Midnight Dynamos rock and roll band. With their unique
-        harmonies and musicianship they add an extra dimension to the Dreamers, who along with the hits of Freddie and The Dreamers perform the 
-        most popular songs of the fifties rock and roll days and the great songs of the sixties.
-
-        �9 Advance or �10 on the Door" />
-        <meta property="og:image" content="https://www.wegottickets.com/images/events/5a6665f87132e_event.png" />
-        <meta property="fbwegottickets:date"   content="2018-09-28"  />
-        <meta property="fbwegottickets:venue"  content="Darlington Harrowgate Club & Institute Ltd" />
-
+        <meta property="og:title" content="Puppy" />
+        <meta property="og:description" content="A fusion of earth-shattering riffs, earworm melodies and anything-goes experimentation, Puppy�s long-awaited debut album The Goat is testament to their go-it-alone attitude. It�s sonic concoction that�s sure to shock - in a world of modern rock copycats, Puppy sound like nothing else out there - delivered with both a knockout punch and a glowing, silly smile.
+        
+        �We love heavier bands that seem to have something smarter going on,� explains frontman and guitarist Jock Norton - who leads the Puppy pack alongside drummer Billy Howard and bassist Will Michael - �but then we also love bands that are pretty dumb!� he adds with a cackle, citing both Black Sabbath�s doomy odes to the occult and Weezer�s admission that, really, they were off playing Dungeons &amp; Dragons as two seemingly opposing forces on his early musical ambitions.
+        
+        Born at the turn of 2015, Puppy emerged from the ashes of a previous, more �garage-y sounding� project. �We just wanted to push the boat out a bit,� says Jock, who acts as the band�s primary songwriter and sonic wizard. March 2015 debut single �Forever� quickly nailed those new colours to the mast. Taking the left-field melodic turns of Weezer, the hazy fuzz of Smashing Pumpkins, and the straight-to-the bone sonics of the Big Four of thrash metal, the group�s idiosyncratic sound is as unique as their batshit, DIY-or-die approach to the visual side of the group (when they�ve got nothing band-wise to create, they make viral memes - you may have seen their Matrix-referencing take on England�s World Cup prospects�) It�s a mixing pot of the trio�s collective interests and ambitions - a fact that sees Will and Billy produce, directi, shoot, and edit all the band�s videos merch designs and even album art - and one that hides a dark, occult-esque heart under its catchy melodies and scream-along, festival-ready choruses.
+        
+        �We had a bit of a wake-up moment,� Jock admits of that more conventional, pre-Puppy past, �and we just thought, �Why are we doing stuff that everyone else is doing, without questioning it?� From there on out, it was individuality, all the way. �That song, �Forever�, has about fifty guitars all layered up,� he laughs of their early attempts to inject some bonkers into the mix. �We wanted to make more of a celebration and an identity out of our differences, rather than the common threads.� Above all, though, they just wanted to create something fucking fun, channeling the assuredness of those yesteryear rockstars into something that eschewed pretension, without ever dipping into pantomime or parody. That approach has seeped into every crack of The Goat - a record that�ll inspire grins from even the most grizzled metalheads, and headbanging from the most hesitant indie kids. �That�s been the mantra of the band, from then � even though the sound�s developed, we�ve kept that mentality of wanting to constantly push ourselves and keep chasing and exploring what seems cool to us,� says Jock.
+        
+        It�s an approach which initially had its pitfalls, Jock admits � while they were more confident than ever in the music they were making, the fact they didn�t fit in a box made finding their feet all the more challenging. �We were always the lightest band on a heavier bill, or the heaviest band on a lighter bill,� he says - occupying a middle ground between the worlds of indie, rock and metal meant finding gig line-ups they could jump on was a Herculean task. Through sheer resilience, self-belief and the storming Vol. 2 EP though, they soon found themselves climbing the ranks of rock royalty. An appearance on Guitar Hero for �Forever� led straight into a packed-out slot at Download Festival 2016 � a festival they were told early on was out of their reach. The following year, they played Glastonbury; soon after that, Bloodstock - a festival double-header that few bands could manage to pull off. A similar eclecticism was exhibited on their choice of tours, which saw them share bills with everyone from glam-punks Creeper, to doom metallers Conan and skater boy icons CKY in those early years. All the while, they collected praise from the likes of The Guardian, Radio 1, Noisey, Kerrang!, DIY, Rock Sound, and more. Their mounting success was evidence that their dedication wasn�t misplaced - following their own path found Puppy a fervent, diverse fanbase. �I don�t think we were sure if we�d get accepted by the rock-ier worlds,� Jock admits - �When you�re not playing those shows, you imagine guys in bullet belts and leather vest with their arms folded, just shaking their heads!�
+        
+        The Goat has plenty to offer everyone � from bullet-belted metalheads to shoegazing fuzz lovers, it�s a record that thrives off its kaleidoscopic approach to creativity and the band�s mischievous mentality. Beginning the process of piecing together The Goat early last year, their plan was simple � �to keep that initial mindset at the forefront,� says Jock, �to do stuff that really excited us.� Entering the studio in the summer of 2017, they leapfrogged every expectation from the off. �I think the songs on the new album are the best songs we�ve written across the board,� he admits. �As much as you can explore new influences, and new sounds, and new textures � at the end of the day, the songs have gotta bang!� It�s a record that, as a result, has no clear pinnacle � every song has been fine-tuned to its most hard-hitting form. �For me, the big thing was to be able to take any song from the album and be happy for that to be the only song of ours that someone heard,� he says of the all-killer-no-filler approach that propelled The Goat.
+        
+        From the guttural stomp of lead single �Black Hole�, via the theatrics of �Nightwalker� and �World Stands Still��s action-movie-montage-ready pomp, no stone is left unturned in Puppy�s desire to push boundaries and � above all � embrace the fun inherent in rock�s former heyday. Jock cites a suitable mish-mash of influences on that mindset � everyone from the aforementioned Black Sabbath and Weezer, to Helmet, Faith No More and Teenage Fanclub got a look in when they were growing up. For the group that would one day become Puppy, Jock admits, there was no tribalism. �Obviously we could tell that one guy�s jeans were a lot baggier than the others�, but generally speaking it was all just guitar music!� he says with a laugh. 
+        
+        That freed-up feeling flows throughout The Goat. A record that dodges convention and pretension at every turn in favour of a fun-first approach, it�s one of the year�s finest guitar albums, from one of the country�s most entrancing new bands." />
+        <meta property="og:image" content="https://www.wegottickets.com/images/events/5c3f36ccabd3f_event.png" />
+        <meta property="fbwegottickets:date"   content="2019-04-24"  />
+        <meta property="fbwegottickets:venue"  content="Leeds The Brudenell Social Club" />
+        
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@WeGotTickets" />
-        <meta name="twitter:title" content="The Dreamers" />
-        <meta name="twitter:description" content="Formerly �Freddie and The Dreamers.� The Dreamers remain one of the best known named bands 
-        on the sixties music circuit. Changes to personnel over the past 50 years were of course inevitable but t..." />
-        <meta name="twitter:image" content="https://www.wegottickets.com/images/events/5a6665f87132e_event.png" />
-
+        <meta name="twitter:title" content="Puppy" />
+        <meta name="twitter:description" content="A fusion of earth-shattering riffs, earworm melodies and anything-goes experimentation, Puppy�s long-awaited debut album The Goat is testament to their go-it-alone attitude. It�s sonic concoction t..." />
+        <meta name="twitter:image" content="https://www.wegottickets.com/images/events/5c3f36ccabd3f_event.png" />
+        
         <script type="text/javascript" src="//cdn.wegottickets.com/www/js/jquery.min.js"></script>
         <script type="text/javascript" src="https://www.wegottickets.com/js/slick.min.js"></script>
         <script type="text/javascript" src="https://www.wegottickets.com/js/crafty_clicks.class.js"></script>
         <script type="text/javascript" src="https://www.wegottickets.com/js/utilities.js"></script>
         <script type="text/javascript" src="https://www.wegottickets.com/js/postcode-lookup.js"></script>
-        <script>var CRAFTY_CLICK_KEY = '06b90-73e63-7a349-015e9';</script>
+        <script type="text/javascript">var CRAFTY_CLICK_KEY = '06b90-73e63-7a349-015e9';</script>
         <script type="text/javascript">
-        jQuery(document).ready(function($) {
-            var starLinks = $('.star-compliance');
-            $(starLinks).each(function() {
-                $(this).click(function (e) {
-                    e.preventDefault();
-                    window.open(
-                        "http://www.star.org.uk/verify?dn=http://www.wegottickets.com",
-                        'star-compliance-window',
-                        "toolbar=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=no,width=560,height=490"
-                    );
+            jQuery(document).ready(function($) {
+                var starLinks = $('.star-compliance');
+                $(starLinks).each(function() {
+                    $(this).click(function (e) {
+                        e.preventDefault();
+                        window.open(
+                            "http://www.star.org.uk/verify?dn=http://www.wegottickets.com",
+                            'star-compliance-window',
+                            "toolbar=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=no,width=560,height=490"
+                        );
+                    });
                 });
             });
-        });
         </script>
-
-        <script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
-        <script>
-            var googletag = googletag || {};
-            googletag.cmd = googletag.cmd || [];
-        </script>
-
-        <script>
-            googletag.cmd.push(function() {
-                googletag.defineSlot('/21624694074/WGT-Bottom_Desktop!728x90', [728, 90], 'div-gpt-ad-1509105203743-0').addService(googletag.pubads());
-                googletag.defineSlot('/21624694074/WGT-Bottom_Mobile!320x50', [320, 50], 'div-gpt-ad-1509105203743-1').addService(googletag.pubads());
-                googletag.defineSlot('/21624694074/WGT-Desktop_Right!300x250', [300, 250], 'div-gpt-ad-1509105203743-2').addService(googletag.pubads());
-                googletag.defineSlot('/21624694074/WGT-Top_Desktop!728x90', [728, 90], 'div-gpt-ad-1509105203743-3').addService(googletag.pubads());
-                googletag.defineSlot('/21624694074/WGT-Mobile_Top!320x50', [320, 50], 'div-gpt-ad-1509105203743-4').addService(googletag.pubads());
-                googletag.pubads().enableSingleRequest();
-                googletag.enableServices();
-            });
-        </script>
+        
+            <script type="text/javascript" async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+            <script type="text/javascript">
+                var googletag = googletag || {};
+                googletag.cmd = googletag.cmd || [];
+            </script>
+        
+            <script type="text/javascript">
+                googletag.cmd.push(function() {
+                    googletag.defineSlot('/21624694074/WGT-Bottom_Desktop!728x90', [728, 90], 'div-gpt-ad-1509105203743-0').addService(googletag.pubads());
+                    googletag.defineSlot('/21624694074/WGT-Bottom_Mobile!320x50', [320, 50], 'div-gpt-ad-1509105203743-1').addService(googletag.pubads());
+                    googletag.defineSlot('/21624694074/WGT-Desktop_Right!300x250', [300, 250], 'div-gpt-ad-1509105203743-2').addService(googletag.pubads());
+                    googletag.defineSlot('/21624694074/WGT-Top_Desktop!728x90', [728, 90], 'div-gpt-ad-1509105203743-3').addService(googletag.pubads());
+                    googletag.defineSlot('/21624694074/WGT-Mobile_Top!320x50', [320, 50], 'div-gpt-ad-1509105203743-4').addService(googletag.pubads());
+                    googletag.pubads().enableSingleRequest();
+                    googletag.enableServices();
+                });
+            </script>
         </head>
         <body>
         <div id="top"></div>
-        <script>
+        <script type='text/javascript'>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
+        
         ga('create', 'UA-56947768-1', 'auto');
         ga('send', 'pageview');
         </script>
         <div class="block-group" id="cookie_agreement">
-        <div class="padded block">
-            <a id="agree_to_cookies" class="agree_to_cookies" href="https://www.wegottickets.com/cookies_agree"><button>X</button></a>
-            <p>We use cookies to track your browsing patterns in order to personalise our content and provide the best user experience possible. If you continue using the site we'll assume you're happy with this.</p>
-        </div>
-        <div class="padded block">
-            <p><a class="agree_to_cookies button advance-filled" href="https://www.wegottickets.com/cookies_agree">Got it, thanks</a>&nbsp;&nbsp;&nbsp;<a class="button cancel-filled" href="https://www.wegottickets.com/cookies">More info</a></p>
-        </div>
+            <div class="padded block">
+                <a id="agree_to_cookies" class="agree_to_cookies" href="https://www.wegottickets.com/cookies_agree"><button>X</button></a>
+                <p>We use cookies to track your browsing patterns in order to personalise our content and provide the best user experience possible. If you continue using the site we'll assume you're happy with this.</p>
+            </div>
+            <div class="padded block">
+                <p><a class="agree_to_cookies button advance-filled" href="https://www.wegottickets.com/cookies_agree">Got it, thanks</a>&nbsp;&nbsp;&nbsp;<a class="button cancel-filled" href="https://www.wegottickets.com/cookies">More info</a></p>
+            </div>
         </div>
         <script type="text/javascript">
-        jQuery(document).ready(function($) {
-            $('a.agree_to_cookies').bind('click', function() {
-                document.cookie = "allow_cookies=Yes; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
-                $('#cookie_agreement').remove();
-                return false;
+            jQuery(document).ready(function($) {
+                $('a.agree_to_cookies').bind('click', function() {
+                    document.cookie = "allow_cookies=Yes; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
+                    $('#cookie_agreement').remove();
+                    return false;
+                });
             });
-        });
         </script>
-        <noscript><img src="//cdn.wegottickets.com/www/images/noscript.gif" style="display: none" /></noscript>
-        <div id="Wrapper">
-        <script>
-        jQuery(document).ready(function($) {
-            try {
-                var currentViewport;
-                var smallLeaderBoardAdNotLoaded = true;
-                var largeLeaderBoardAdNotLoaded = true;
-                var mpuAdNotLoaded = true;
-                var smallBottomBoardAdNotLoaded = true;
-                var largeBottomBoardAdNotLoaded = true;
-                
-                function onResize() {
-                    if (window.innerWidth <= 767) {
-                        if (currentViewport != 'mobile') {
-                            if ((smallLeaderBoardAdNotLoaded) || (!largeLeaderBoardAdNotLoaded)){
-                                document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Mobile_Top!320x50 --><div id='div-gpt-ad-1509105203743-4' style='height:50px; width:320px; position: relative;' class='leaderboard'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-4'); });
-                            }
-                            if ((smallBottomBoardAdNotLoaded) || (!largeBottomBoardAdNotLoaded)){
-                                document.getElementById('bottomboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Bottom_Mobile!320x50 --><div id='div-gpt-ad-1509105203743-1' style='height:50px; width:320px;'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-1'); });
-                            }
-                        }
-                        
-                        currentViewport = 'mobile';
-                        smallLeaderBoardAdNotLoaded = false;
-                    } else if (window.innerWidth <= 990) {
-                        if (currentViewport != 'tablet') {
-                            if ((largeLeaderBoardAdNotLoaded) || (!smallLeaderBoardAdNotLoaded)) {
-                                document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Top_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-3' style='height:90px; width:728px; position: relative;' class='leaderboard'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-3'); });
-                            }
-                            
-                            if ((largeBottomBoardAdNotLoaded) || (!smallBottomBoardAdNotLoaded)) {
-                                document.getElementById('bottomboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Bottom_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-0' style='height:90px; width:728px;'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-0'); });
-                            }
-                            
-                        }
-                        
-                        currentViewport = 'tablet';
-                    } else if (window.innerWidth > 990) {
-                        if (currentViewport != 'desktop')  {
-                            if (mpuAdNotLoaded && document.getElementById('mpu-ad-placeholder')) {
-                                document.getElementById('mpu-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Desktop_Right!300x250 --><div id='div-gpt-ad-1509105203743-2' style='width:300px;'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-2'); });
-                            };
-                            
-                            if ((largeLeaderBoardAdNotLoaded) || (!smallLeaderBoardAdNotLoaded)){
-                                document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Top_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-3' style='height:90px; width:728px; position: relative;' class='leaderboard'><\/div>";
-                                googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-3'); });
-                            }
-                        }
-                        
-                        currentViewport = 'desktop';
-                        mpuAdNotLoaded = false;
-                        largeLeaderBoardAdNotLoaded = false;
-                    }
-                }
-                
-                onResize();
-                
-                /* Add Listeners for adverts */
-                if (window.addEventListener) {
-                    window.addEventListener('resize', onResize, true);
-                }
-            } catch (err) {
-                // the ads don't run, whatever
-            }
-        });
-        </script>
-        <div class="ad-banner">
-        <div id="leaderboard-ad-placeholder"></div>
-
-        <div class="leaderboard switch_placeholder">
-            <noscript>
-                <a href="/about" title="About WeGotTickets">
-                    <img class="small-hidden"  src="https://www.wegottickets.com/images/rebrand/houseads/leaderboard_fees.png"   alt="WeGotTickets low booking fees">
-                    <img class="medium-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/mobile_transparent.png" alt="WeGotTickets against dodgy practices">
-                </a>
-            </noscript>
-        </div>
-        </div>
-
-        <div id="Header" class="filled">
-            
-            <div class="content block-group">
-                <div id="Navigation">
-                    <div class="sub-nav block">
-                        <ul>
-                            <li>
-        <a title="Login to WeGotTickets" class="login neutral-filled" href="https://www.wegottickets.com/account">Login</a>
-        </li>
-        <li>
-        <a title="Register with WeGotTickets" class="register neutral-filled" href="https://www.wegottickets.com/register">Register</a>
-        </li>
-
-                            <li>
-                                <a title="Basket" class="basket advance-filled" href="/viewcart">Basket</a>
-                            </li>
-                        </ul>
-                        <ul>
-                            <li>
-                                <a title="About WeGotTickets" href="/about">About us</a>
-                            </li>
-                            <li>
-                                <a title="Ticket your event with WeGotTickets" href="https://clients.wegottickets.com/?cc=cs-header" target="_blank">Ticket your event</a>
-                            </li>
-                            <li>
-                                <a title="FAQs" href="/faqs">FAQs</a>
-                            </li>
-                        </ul>
-                    </div>
-                    <ul id="mobile-nav">
-                        <li class="css-menu">
-                            <a class="menu-over">
-                                <img src="https://www.wegottickets.com/images/hamburger.png" alt="Menu" title="Main menu"/>
-                            </a>
-                            <a class="css-menu-button advance-filled" tabindex="1" href="#">
-                                <img src="https://www.wegottickets.com/images/hamburger.png" alt="Menu" title="Main menu"/>
-                            </a>
-                            <ul class="dropdown-menu">
-                                <li><a title="About us" href="/about">About us</a></li>
-                                <li><a title="Ticket your event" href="https://clients.wegottickets.com/?cc=cs-header" target="_blank">Ticket your event</a></li>
-                                <li><a title="FAQs" id="Faqs" href="https://www.wegottickets.com/faqs">FAQs</a></li>
-                                <li><a title="Basket" id="Basket" href="https://www.wegottickets.com/viewcart" class="advance-filled">Basket</a></li>
-                                <li>
-        <a title="Login to WeGotTickets" class="login neutral-filled" href="https://www.wegottickets.com/account">Login</a>
-        </li>
-        <li>
-        <a title="Register with WeGotTickets" class="register neutral-filled" href="https://www.wegottickets.com/register">Register</a>
-        </li>
-
-                            </ul>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="content block-group block-group-flex">
-                <div class="logo block diptych">
-                    <a href="/">
-                        <h1>
-                            WeGotTickets
-                            <sup>?</sup>
-                            - Simple, honest ticketing.
-                        </h1>
-                        <img src="https://www.wegottickets.com/rebrand/images/wegottickets_logo_lg.png">
-                    </a>
-                </div>
-                <div class="block block-header-search diptych padded">
-                    <form id="search-form" action="/searchresults" method="post">
-                        <input class="search-form" type="text" name="unified_query" placeholder="artist, event, venue, town, promoter...">
-                        <input class="button advance-filled search-form" type="submit" value=" ">
-                    </form>
-                </div>
-            </div>
-        </div>
-        <div id="WrapperInner">
-            <div id="Page" class="clearfix">
-                <div id="Content" class="clearfix" >
-                    <div id="extra_content"></div>
-        <script type="text/javascript">
-        window.onload = function () {
-            function xhr_request(target) {
-                var xhr;
-                
-                try {
-                    xhr = new XMLHttpRequest();
-                } catch (e) {
-                    try {
-                        xhr = new ActiveXObject("Msxml2.XMLHTTP");
-                    } catch (e) {
-                        xhr = new ActiveXObject("Microsoft.XMLHTTP");
-                    }
-                }
-                
-                xhr.open("GET", target, true);
-                
-                xhr.onreadystatechange = function() {};
-                
-                xhr.send(null);
-            }
-
-            var streetMap = document.getElementById('StreetmapAnchor');
-
-            if (streetMap) {
-                streetMap.onclick = function () {
-                    xhr_request('/images/streetmap.jpg?gig=429096');
-                }
-            }
-        };
-
-        jQuery(document).ready(function() {
-            jQuery.fn.handleQuantityChange = function() {
-                var quantity = parseInt(jQuery(this).val());
-                var max      = parseInt(jQuery(this).attr('max'));
-                
-                // show buy buttons if applicable
-                if (quantity >= 1) {
-                    // show plus/minus buttons; hide buy button
-                    jQuery(this).show().siblings('input, button').show();
-                    jQuery(this).siblings('button[name="buy"]').hide();
-                } else {
-                    // hide plus/minus buttons; show buy button
-                    jQuery(this).hide().siblings('input, button').hide();
-                    jQuery(this).siblings('button[name="buy"]').show();
-                }
-                
-                // if quantity at maximum, hide plus button
-                if (quantity === max) {
-                    jQuery(this).siblings('button[name="+"]').hide();
-                }
-                
-                return jQuery(this);
-            };
-            
-            jQuery('button[name="buy"]').on("click submit", function(e) {
-                e.preventDefault();
-
-                // trigger the proper 'add 1 to basket' functionality
-                // so we can check if we're going above max per order etc.
-                jQuery(this).siblings('button[name="+"]').trigger('click');
-            });
-            
-            jQuery('input[name="qty[]"]').on("change keyup touchend", function() {
-                var quantity = parseInt(jQuery(this).val());
-                var max      = parseInt(jQuery(this).attr('max'));
-                
-                if (quantity > max) {
-                    jQuery(this).val(max);
-                    // todo give 'max per order' feedback to user
-                }
-            });
-
-            // decrement
-            jQuery('button[name="-"]').on("click submit", function(e) {
-                e.preventDefault();
-                
-                var $quantity = jQuery(this).siblings('input[name="qty[]"]');
-                
-                $quantity.val(parseInt($quantity.val())  - 1);
-                $quantity.handleQuantityChange()
-            });
-
-            // increment
-            jQuery('button[name="+"]').on("click submit", function(e) {
-                e.preventDefault();
-
-                var $quantity = jQuery(this).siblings('input[name="qty[]"]');
-
-                $quantity.val(parseInt($quantity.val()) + 1);
-                $quantity.handleQuantityChange()
-            });
-            
-            jQuery('input[name="qty[]"').each(jQuery.fn.handleQuantityChange);
-        });
-        </script>
-
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"MusicEvent","name":"The Dreamers","description":"Formerly &#039;Freddie and The Dreamers.&#039; The Dreamers remain one of the best known named bands \non the sixties music circuit. Changes to personnel over the past 50 years were of course inevitable but two members \nAlan Mosca and Bryan Byng remain in the band today, they have been in the band as &#039;Freddie and The Dreamers&#039;\n&amp;#8203;and then &#039;The Dreamers&#039; for over 40 years.\nAlan and Bryan are joined by The Temple Brothers, Steve and Colin who in their own right are seasoned professionals having\ntoured extensively with their Everly Brothers tribute show and Midnight Dynamos rock and roll band. With their unique\nharmonies and musicianship they add an extra dimension to the Dreamers, who along with the hits of Freddie and The Dreamers perform the \nmost popular songs of the fifties rock and roll days and the great songs of the sixties.\n\n&pound;9 Advance or &pound;10 on the Door","startDate":"2018-09-28T18:30:00+01:00","location":{"@type":"Place","name":"Darlington Harrowgate Club &amp; Institute Ltd","address":"Salters Lane North|Darlington|County Durham|DL1 3DT|","url":"http://www.harrowgateclubandinstituteltd.co.uk","telephone":"01325 463905"},"eventStatus":"EventScheduled","url":"http://www.wegottickets.com/event/429096","offers":[{"@type":"Offer","category":"Primary","availability":"InStock","price":"9.9","priceCurrency":"GBP","inventoryLevel":"239","url":"http://www.wegottickets.com/event/429096","availabilityStarts":"","availabilityEnds":""}]}</script>
-
-        <div class="content">
-
-        <div class="block-group">
-            <div class="left block">
-                <div class="event-image left full-width-mobile">
-                    <img src="https://www.wegottickets.com/images/events/5a6665f87132e_event.png"/>
-                </div>
-                <div class="left full-width-mobile event-information event-width">
-                    <h1>THE DREAMERS</h1>
-                    <h4 class="support"></h4>
-                    <div class="venue-details">
-                        <h2>DARLINGTON: Harrowgate Club & Institute Ltd</h2>
-                        <h4>FRI 28TH SEP, 2018 6:30pm</h4>
-                    </div>
-                    
-                </div>
-            </div>
-        </div>
-
-        <div class="full-width">
-            <hr />
-            
-        <p id="eventinfo">Formerly �Freddie and The Dreamers.� The Dreamers remain one of the best known named bands <br />on the sixties music circuit. Changes to personnel over the past 50 years were of course inevitable but two members� <br />Alan Mosca and Bryan Byng remain in the band today, they have been in the band as 'Freddie and The Dreamers'<br />&#8203;and then 'The Dreamers' for over 40 years.<br />Alan and Bryan are joined by The Temple Brothers, Steve and Colin who in their own right are seasoned professionals having<br />toured extensively with their Everly Brothers tribute show and Midnight Dynamos rock and roll band. With their unique<br />harmonies and musicianship they add an extra dimension to the Dreamers, who along with the hits of Freddie and The Dreamers perform the <br />most popular songs of the fifties rock and roll days and the great songs of the sixties.<br /><br />�9 Advance or �10 on the Door</p>
-
-            <div class="addthis_inline_share_toolbox"></div>
-            <div class="VariantAlert"></div>
-        </div>
-
-
-        <div class="block-group neutral-filled padded section-margins">
-            <h4>Tickets</h4>
-        </div>
-
-        <div class="block-group block-group-flex">
-            <form method="post" action="https://www.wegottickets.com/action" class="full-width">
-                <input type="hidden" name="action" value="basket" />
-                <input type="hidden" name="type" value="addmany" />
-                
-        <div class="BuyBox block">
-            <h2>General Admission</h2>
-            
-            <table class="full-width">
-                <tbody>
-                    <tr>
-                        <td class="half text-top">
-                            <p></p>
-                            <p>18 and over</p>
-                        </td>
-                        <td class="half text-top text-right">
-                            <p>&pound;9.00 + &pound;0.90 Booking fee = <strong>&pound;9.90</strong></p>
-                            
-        <span><a href="https://www.wegottickets.com/faqs/7" class="offsaleLink">Not currently available</a></span>
-
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-
-                
-            </form>
-        </div>
-
-        </div>
-
-                            
-
-        <div>
-
-        <ul></ul>
-        </div>
-
-        <div class="EventLocation">
-        <div class="section-margins neutral-filled padded">
-            <h4>Venue Information</h4>
-        </div>
-
-        <ul class="block-group clearfix">
-            <li class="diptych block">
-                <p>
-                    <a href="https://www.wegottickets.com/location/17859"><strong>DARLINGTON: Harrowgate Club & Institute Ltd</strong></a>
-                    <br/>
-                    Salters Lane North<br />Darlington<br />County Durham<br />DL1 3DT<br /><br/>
-                    <br/>
-                    Large car park at the rear of the club
-                </p>
-            </li>
-            
-            <li class="diptych block">
-                <p id="venueWebsite"><a href="http://www.harrowgateclubandinstituteltd.co.uk" target="_blank">website</a> &nbsp;</p>
-                <p id="venueTelephone">01325 463905 &nbsp;</p>
-                <p><p id="StreetmapLink"><a id="StreetmapAnchor" href="http://www.streetmap.co.uk/streetmap.dll?G2M?X=429737&Y=517258&A=Y&Z=1" target="_blank">Map of the venue location (Streetmap)</a></p></p>
-            </li>
-        </ul>
-
-        <div id="seatingPlan">
-            <div></div>
-        </div>
-        </div>
-
-        <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4ee211b53db2f064"></script>
-
-                        </div>
-                    </div>
-                    <div id="RightColumn">
-                        
-                        <div class="content padded filled chatterbox-margin">
-        <div class="panel-heading">
-            <h3 class="neutral">Simple, honest ticketing.</h3>
-        </div>
-        <div class="panel-body">
-            In the sometimes murky world of ticket sales, WeGotTickets are the box office the nation trusts to be the good
-            guys.
-            <ul class="values">
-                <li class="cat-newsletter">
-                    <h4>Instant e-ticket delivery</h4>
-                    <p>Our tickets are delivered to your inbox, not by post.</p>
-                </li>
-                <li class="cat-fees">
-                    <h4>Affordable, transparent fees</h4>
-                    <p>We won't rip you off to line someone else's pockets.</p>
-                </li>
-                <li class="cat-custservice">
-                    <h4>Amazing customer service</h4>
-                    <p>Our support staff's award winning service won't let you down.</p>
-                </li>
-            </ul>
-            <a name="Find out more about WeGotTickets and our values." href="/about"> Find out more
-                about WeGotTickets and our values. </a>
-        </div>
-        </div>
-        <div class="mpu chatterbox-margin">
-        <a href="http://www.wegottickets.com/about"><img src="https://www.wegottickets.com/images/features/DYKcustomerservice1515673337.jpg" alt="" /></a>
-        </div>
-        <!-- /3595/uk_WeGotTickets -->
-        <div class="mpu mpu_placeholder chatterbox-margin">
-        <div id="mpu-ad-placeholder"></div>
         <noscript>
-            <a href="http://blog.wegottickets.com/about-indie50/">
-                <img src="https://www.wegottickets.com/images/rebrand/houseads/mpu_blog.png">
-            </a>
+            <img src="//cdn.wegottickets.com/www/images/noscript.gif" style="display: none" alt="noscript"/>
         </noscript>
-        </div>
-        <div class="mpu chatterbox-margin">
-        <a href="https://clients.wegottickets.com/?cc=fireworks-button"><img src="https://www.wegottickets.com/images/features/Fireworks1506610157.jpg" alt="" /></a>
-        </div>
-
-                    </div>
-                </div>
-            </div>
-            <footer id="footer">
-                <div class="medium-hidden">
-                    <div class="content">
-                        <div class="padded">
-                            <a href="#top" id="back-to-top" class="button highlight-filled full-width"
-                                title="Back to top"> Back to top </a>
-                        </div>
-                    </div>
-                </div>
-                <div id="newsletter" class="small-hidden filled">
-                    <div class="content">
-                        <span class="icon"></span>
-                        <h4>Sign-up to our newsletter</h4>
-                        <form id="newsletter-signup" method="post" action="/mailing">
-                            <input type="text" name="ml_email" placeholder="Enter email address..."/>
-                            <input type="hidden" name="ml_region" value="0"/>
-                            <input type="hidden" name="ml_format" value="html"/>
-                            <input class="button neutral-filled" name="submit" type="submit" value="Sign-up"/>
-                        </form>
-                    </div>
-                </div>
+        <div id="Wrapper">
+            <script type="text/javascript">//<![CDATA[
+            jQuery(document).ready(function($) {
+                try {
+                    var currentViewport;
+                    var smallLeaderBoardAdNotLoaded = true;
+                    var largeLeaderBoardAdNotLoaded = true;
+                    var mpuAdNotLoaded = true;
+                    var smallBottomBoardAdNotLoaded = true;
+                    var largeBottomBoardAdNotLoaded = true;
                     
-            <div class="bottomboard mpu_placeholder">
-                    <div id="bottomboard-ad-placeholder"></div>
+                    function onResize() {
+                        if (window.innerWidth <= 767) {
+                            if (currentViewport != 'mobile') {
+                                if ((smallLeaderBoardAdNotLoaded) || (!largeLeaderBoardAdNotLoaded)){
+                                    document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Mobile_Top!320x50 --><div id='div-gpt-ad-1509105203743-4' style='height:50px; width:320px; position: relative;' class='leaderboard'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-4'); });
+                                }
+                                if ((smallBottomBoardAdNotLoaded) || (!largeBottomBoardAdNotLoaded)){
+                                    document.getElementById('bottomboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Bottom_Mobile!320x50 --><div id='div-gpt-ad-1509105203743-1' style='height:50px; width:320px;'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-1'); });
+                                }
+                            }
+                            
+                            currentViewport = 'mobile';
+                            smallLeaderBoardAdNotLoaded = false;
+                        } else if (window.innerWidth <= 990) {
+                            if (currentViewport != 'tablet') {
+                                if ((largeLeaderBoardAdNotLoaded) || (!smallLeaderBoardAdNotLoaded)) {
+                                    document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Top_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-3' style='height:90px; width:728px; position: relative;' class='leaderboard'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-3'); });
+                                }
+                                
+                                if ((largeBottomBoardAdNotLoaded) || (!smallBottomBoardAdNotLoaded)) {
+                                    document.getElementById('bottomboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Bottom_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-0' style='height:90px; width:728px;'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-0'); });
+                                }
+                            
+                            }
+                            
+                            currentViewport = 'tablet';
+                        } else if (window.innerWidth > 990) {
+                            if (currentViewport != 'desktop')  {
+                                if (mpuAdNotLoaded && document.getElementById('mpu-ad-placeholder')) {
+                                    document.getElementById('mpu-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Desktop_Right!300x250 --><div id='div-gpt-ad-1509105203743-2' style='width:300px;'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-2'); });
+                                };
+                                
+                                if ((largeLeaderBoardAdNotLoaded) || (!smallLeaderBoardAdNotLoaded)){
+                                    document.getElementById('leaderboard-ad-placeholder').innerHTML = "<!-- /21624694074/WGT-Top_Desktop!728x90 --><div id='div-gpt-ad-1509105203743-3' style='height:90px; width:728px; position: relative;' class='leaderboard'><\/div>";
+                                    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1509105203743-3'); });
+                                }
+                            }
+                            
+                            currentViewport = 'desktop';
+                            mpuAdNotLoaded = false;
+                            largeLeaderBoardAdNotLoaded = false;
+                        }
+                    }
+                    
+                    onResize();
+                    
+                    /* Add Listeners for adverts */
+                    if (window.addEventListener) {
+                        window.addEventListener('resize', onResize, true);
+                    }
+                } catch (err) {
+                    // the ads don't run, whatever
+                }
+            });
+        //]]></script>
+        <div class="ad-banner">
+            <div id="leaderboard-ad-placeholder"></div>
+        
+            <div class="leaderboard switch_placeholder">
                 <noscript>
-                    <a class="small-hidden" href="/about" title="About WeGotTickets">
-                        <img class="small-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/leaderboard_environment.png" alt="Our e-ticket systems emits 1000 times less carbon than postal tickets">
-                    </a>
-                    <a class="medium-hidden" href="http://blog.wegottickets.com/about-indie50/">
-                        <img class="medium-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/mobile_indie50.png" alt="WeGotTickets Indie50 blog">
+                    <a href="/about" title="About WeGotTickets">
+                        <img class="small-hidden"  src="https://www.wegottickets.com/images/rebrand/houseads/leaderboard_fees.png"   alt="WeGotTickets low booking fees" />
+                        <img class="medium-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/mobile_transparent.png" alt="WeGotTickets against dodgy practices" />
                     </a>
                 </noscript>
             </div>
-                <div class="social-icons filled">
-                    <a href="https://twitter.com/wegottickets" name="@WeGotTickets Twitter account">
-                        <img src="https://www.wegottickets.com/rebrand/images/icons/ico-twitter_32.png" name="@WeGotTickets on Twitter"
+        </div>
+        
+            <div id="Header" class="filled">
+                
+                <div class="content block-group">
+                    <div id="Navigation">
+                        <div class="sub-nav block">
+                            <ul>
+                                <li>
+            <a title="Login to WeGotTickets" class="login neutral-filled" href="https://www.wegottickets.com/account">Login</a>
+        </li>
+        <li>
+            <a title="Register with WeGotTickets" class="register neutral-filled" href="https://www.wegottickets.com/register">Register</a>
+        </li>
+        
+                                <li>
+                                    <a title="Basket" class="basket advance-filled" href="/viewcart">Basket</a>
+                                </li>
+                            </ul>
+                            <ul>
+                                <li>
+                                    <a title="About WeGotTickets" href="/about">About us</a>
+                                </li>
+                                <li>
+                                    <a title="Ticket your event with WeGotTickets" href="https://clients.wegottickets.com/?cc=cs-header" target="_blank">Ticket your event</a>
+                                </li>
+                                <li>
+                                    <a title="FAQs" href="/faqs">FAQs</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <ul id="mobile-nav">
+                            <li class="css-menu">
+                                <a class="menu-over">
+                                    <img src="https://www.wegottickets.com/images/hamburger.png" alt="Menu" title="Main menu"/>
+                                </a>
+                                <a class="css-menu-button advance-filled" tabindex="1" href="#">
+                                    <img src="https://www.wegottickets.com/images/hamburger.png" alt="Menu" title="Main menu"/>
+                                </a>
+                                <ul class="dropdown-menu">
+                                    <li><a title="About us" href="/about">About us</a></li>
+                                    <li><a title="Ticket your event" href="https://clients.wegottickets.com/?cc=cs-header" target="_blank">Ticket your event</a></li>
+                                    <li><a title="FAQs" id="Faqs" href="https://www.wegottickets.com/faqs">FAQs</a></li>
+                                    <li><a title="Basket" id="Basket" href="https://www.wegottickets.com/viewcart" class="advance-filled">Basket</a></li>
+                                    <li>
+            <a title="Login to WeGotTickets" class="login neutral-filled" href="https://www.wegottickets.com/account">Login</a>
+        </li>
+        <li>
+            <a title="Register with WeGotTickets" class="register neutral-filled" href="https://www.wegottickets.com/register">Register</a>
+        </li>
+        
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="content block-group block-group-flex">
+                    <div class="logo block diptych">
+                        <a href="/">
+                            <h1>
+                                WeGotTickets
+                                <sup>?</sup>
+                                - Simple, honest ticketing.
+                            </h1>
+                            <img src="https://www.wegottickets.com/rebrand/images/wegottickets_logo_lg.png" alt="WeGotTickets logo" />
+                        </a>
+                    </div>
+                    <div class="block block-header-search diptych padded">
+                        <form id="search-form" action="/searchresults" method="post">
+                            <input class="search-form" type="text" name="unified_query" placeholder="artist, event, venue, town, promoter..." />
+                            <input class="button advance-filled search-form" type="submit" value=" " />
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div id="WrapperInner">
+                <div id="Page" class="clearfix">
+                    <div id="Content" class="clearfix" >
+                        <div id="extra_content"></div>
+        <script type="text/javascript">
+            window.onload = function () {
+                function xhr_request(target) {
+                    var xhr;
+                    
+                    try {
+                        xhr = new XMLHttpRequest();
+                    } catch (e) {
+                        try {
+                            xhr = new ActiveXObject("Msxml2.XMLHTTP");
+                        } catch (e) {
+                            xhr = new ActiveXObject("Microsoft.XMLHTTP");
+                        }
+                    }
+                    
+                    xhr.open("GET", target, true);
+                    
+                    xhr.onreadystatechange = function() {};
+                    
+                    xhr.send(null);
+                }
+        
+                var streetMap = document.getElementById('StreetmapAnchor');
+        
+                if (streetMap) {
+                    streetMap.onclick = function () {
+                        xhr_request('/images/streetmap.jpg?gig=461540');
+                    }
+                }
+            };
+            
+            jQuery(document).ready(function() {
+                jQuery.fn.handleQuantityChange = function() {
+                    var quantity = parseInt(jQuery(this).val());
+                    var max = parseInt(jQuery(this).attr('max'));
+        
+                    var totalQuantity = 0;
+        
+                    jQuery('input[name="qty[]"]').each(function() {
+                        totalQuantity += parseInt(jQuery(this).val());
+                    });
+        
+                    // show buy buttons if applicable
+                    if (quantity >= 1) {
+                        // show plus/minus buttons; hide buy button
+                        jQuery(this).show().siblings('input, button').show();
+                        jQuery(this).siblings('button[name="buy"]').hide();
+                    } else {
+                        // hide plus/minus buttons; show buy button
+                        jQuery(this).hide().siblings('input, button').hide();
+                        jQuery(this).siblings('button[name="buy"]').show();
+                    }
+                    
+                    // if quantity at maximum, hide plus button
+                    if (quantity === max) {
+                        jQuery(this).siblings('button[name="+"]').hide();
+                    }
+        
+                    if (totalQuantity > 0) {
+                        jQuery('.proceed').show();
+                    } else {
+                        jQuery('.proceed').hide();
+                    }
+                    
+                    return jQuery(this);
+                };
+                
+                jQuery('button[name="buy"]').on("click submit", function(e) {
+                    e.preventDefault();
+        
+                    // trigger the proper 'add 1 to basket' functionality
+                    // so we can check if we're going above max per order etc.
+                    jQuery(this).siblings('button[name="+"]').trigger('click');
+                });
+                
+                jQuery('input[name="qty[]"]').on("change keyup touchend", function() {
+                    var quantity = parseInt(jQuery(this).val());
+                    var max      = parseInt(jQuery(this).attr('max'));
+                    
+                    if (quantity > max) {
+                        jQuery(this).val(max);
+                        // todo give 'max per order' feedback to user
+                    }
+                });
+        
+                // decrement
+                jQuery('button[name="-"]').on("click submit", function(e) {
+                    e.preventDefault();
+                    
+                    var $quantity = jQuery(this).siblings('input[name="qty[]"]');
+                    
+                    $quantity.val(parseInt($quantity.val())  - 1);
+                    $quantity.handleQuantityChange()
+                });
+        
+                // increment
+                jQuery('button[name="+"]').on("click submit", function(e) {
+                    e.preventDefault();
+        
+                    var $quantity = jQuery(this).siblings('input[name="qty[]"]');
+        
+                    $quantity.val(parseInt($quantity.val()) + 1);
+                    $quantity.handleQuantityChange()
+                });
+                
+                jQuery('input[name="qty[]"').each(jQuery.fn.handleQuantityChange);
+            });
+        </script>
+        
+        <script type="application/ld+json">{"@context":"http://schema.org","@type":"MusicEvent","name":"Puppy","description":"A fusion of earth-shattering riffs, earworm melodies and anything-goes experimentation, Puppy&#039;s long-awaited debut album The Goat is testament to their go-it-alone attitude. It&#039;s sonic concoction that&#039;s sure to shock - in a world of modern rock copycats, Puppy sound like nothing else out there - delivered with both a knockout punch and a glowing, silly smile.\n\nWe love heavier bands that seem to have something smarter going on, explains frontman and guitarist Jock Norton - who leads the Puppy pack alongside drummer Billy Howard and bassist Will Michael - but then we also love bands that are pretty dumb! he adds with a cackle, citing both Black Sabbath&#039;s doomy odes to the occult and Weezer&#039;s admission that, really, they were off playing Dungeons &amp; Dragons as two seemingly opposing forces on his early musical ambitions.\n\nBorn at the turn of 2015, Puppy emerged from the ashes of a previous, more garage-y sounding project. We just wanted to push the boat out a bit, says Jock, who acts as the band&#039;s primary songwriter and sonic wizard. March 2015 debut single &#039;Forever&#039; quickly nailed those new colours to the mast. Taking the left-field melodic turns of Weezer, the hazy fuzz of Smashing Pumpkins, and the straight-to-the bone sonics of the Big Four of thrash metal, the group&#039;s idiosyncratic sound is as unique as their batshit, DIY-or-die approach to the visual side of the group (when they&#039;ve got nothing band-wise to create, they make viral memes - you may have seen their Matrix-referencing take on England&#039;s World Cup prospects) It&#039;s a mixing pot of the trio&#039;s collective interests and ambitions - a fact that sees Will and Billy produce, directi, shoot, and edit all the band&#039;s videos merch designs and even album art - and one that hides a dark, occult-esque heart under its catchy melodies and scream-along, festival-ready choruses.\n\nWe had a bit of a wake-up moment, Jock admits of that more conventional, pre-Puppy past, and we just thought, &#039;Why are we doing stuff that everyone else is doing, without questioning it? From there on out, it was individuality, all the way. That song, &#039;Forever&#039;, has about fifty guitars all layered up, he laughs of their early attempts to inject some bonkers into the mix. We wanted to make more of a celebration and an identity out of our differences, rather than the common threads. Above all, though, they just wanted to create something fucking fun, channeling the assuredness of those yesteryear rockstars into something that eschewed pretension, without ever dipping into pantomime or parody. That approach has seeped into every crack of The Goat - a record that&#039;ll inspire grins from even the most grizzled metalheads, and headbanging from the most hesitant indie kids. That&#039;s been the mantra of the band, from then  even though the sound&#039;s developed, we&#039;ve kept that mentality of wanting to constantly push ourselves and keep chasing and exploring what seems cool to us, says Jock.\n\nIt&#039;s an approach which initially had its pitfalls, Jock admits  while they were more confident than ever in the music they were making, the fact they didn&#039;t fit in a box made finding their feet all the more challenging. We were always the lightest band on a heavier bill, or the heaviest band on a lighter bill, he says - occupying a middle ground between the worlds of indie, rock and metal meant finding gig line-ups they could jump on was a Herculean task. Through sheer resilience, self-belief and the storming Vol. 2 EP though, they soon found themselves climbing the ranks of rock royalty. An appearance on Guitar Hero for &#039;Forever&#039; led straight into a packed-out slot at Download Festival 2016  a festival they were told early on was out of their reach. The following year, they played Glastonbury; soon after that, Bloodstock - a festival double-header that few bands could manage to pull off. A similar eclecticism was exhibited on their choice of tours, which saw them share bills with everyone from glam-punks Creeper, to doom metallers Conan and skater boy icons CKY in those early years. All the while, they collected praise from the likes of The Guardian, Radio 1, Noisey, Kerrang!, DIY, Rock Sound, and more. Their mounting success was evidence that their dedication wasn&#039;t misplaced - following their own path found Puppy a fervent, diverse fanbase. I don&#039;t think we were sure if we&#039;d get accepted by the rock-ier worlds, Jock admits - When you&#039;re not playing those shows, you imagine guys in bullet belts and leather vest with their arms folded, just shaking their heads!\n \nThe Goat has plenty to offer everyone  from bullet-belted metalheads to shoegazing fuzz lovers, it&#039;s a record that thrives off its kaleidoscopic approach to creativity and the band&#039;s mischievous mentality. Beginning the process of piecing together The Goat early last year, their plan was simple  to keep that initial mindset at the forefront, says Jock, to do stuff that really excited us. Entering the studio in the summer of 2017, they leapfrogged every expectation from the off. I think the songs on the new album are the best songs we&#039;ve written across the board, he admits. As much as you can explore new influences, and new sounds, and new textures  at the end of the day, the songs have gotta bang! It&#039;s a record that, as a result, has no clear pinnacle  every song has been fine-tuned to its most hard-hitting form. For me, the big thing was to be able to take any song from the album and be happy for that to be the only song of ours that someone heard, he says of the all-killer-no-filler approach that propelled The Goat.\n\nFrom the guttural stomp of lead single &#039;Black Hole&#039;, via the theatrics of &#039;Nightwalker&#039; and &#039;World Stands Still&#039;&#039;s action-movie-montage-ready pomp, no stone is left unturned in Puppy&#039;s desire to push boundaries and  above all  embrace the fun inherent in rock&#039;s former heyday. Jock cites a suitable mish-mash of influences on that mindset  everyone from the aforementioned Black Sabbath and Weezer, to Helmet, Faith No More and Teenage Fanclub got a look in when they were growing up. For the group that would one day become Puppy, Jock admits, there was no tribalism. Obviously we could tell that one guy&#039;s jeans were a lot baggier than the others&#039;, but generally speaking it was all just guitar music! he says with a laugh. \n \nThat freed-up feeling flows throughout The Goat. A record that dodges convention and pretension at every turn in favour of a fun-first approach, it&#039;s one of the year&#039;s finest guitar albums, from one of the country&#039;s most entrancing new bands.","startDate":"2019-04-24T19:30:00+01:00","location":{"@type":"Place","name":"Leeds Brudenell Social Club","address":"33 Queens Road Leeds West Yorkshire LS6 1NY","url":"http://www.brudenellsocialclub.co.uk","telephone":"01132752411"},"eventStatus":"EventScheduled","url":"http://www.wegottickets.com/event/461540","offers":[{"@type":"Offer","category":"Primary","availability":"InStock","price":"11","priceCurrency":"GBP","inventoryLevel":"25","url":"http://www.wegottickets.com/event/461540","availabilityStarts":"","availabilityEnds":""}]}</script>
+        
+        <div class="content">
+            
+            <div class="block-group">
+                <div class="left block">
+                    <div class="event-image left full-width-mobile">
+                        <img src="https://www.wegottickets.com/images/events/5c3f36ccabd3f_event.png"/>
+                    </div>
+                    <div class="left full-width-mobile event-information event-width">
+                        <h1>PUPPY</h1>
+                        <h4 class="support">Green Lung</h4>
+                        <div class="venue-details">
+                            <h2>LEEDS: The Brudenell Social Club</h2>
+                            <span class="doorTime">
+                                Wed 24th Apr, 2019
+                                <br>
+                                Door time: 7:30pm
+                            </span>
+                        </div>
+                        
+                    </div>
+                </div>
+            </div>
+        
+            <div class="full-width">
+                <hr />
+                
+            <p id="eventinfo">A fusion of earth-shattering riffs, earworm melodies and anything-goes experimentation, Puppy�s long-awaited debut album The Goat is testament to their go-it-alone attitude. It�s sonic concoction that�s sure to shock - in a world of modern rock copycats, Puppy sound like nothing else out there - delivered with both a knockout punch and a glowing, silly smile.<br /><br />�We love heavier bands that seem to have something smarter going on,� explains frontman and guitarist Jock Norton - who leads the Puppy pack alongside drummer Billy Howard and bassist Will Michael - �but then we also love bands that are pretty dumb!� he adds with a cackle, citing both Black Sabbath�s doomy odes to the occult and Weezer�s admission that, really, they were off playing Dungeons & Dragons as two seemingly opposing forces on his early musical ambitions.<br /><br />Born at the turn of 2015, Puppy emerged from the ashes of a previous, more �garage-y sounding� project. �We just wanted to push the boat out a bit,� says Jock, who acts as the band�s primary songwriter and sonic wizard. March 2015 debut single �Forever� quickly nailed those new colours to the mast. Taking the left-field melodic turns of Weezer, the hazy fuzz of Smashing Pumpkins, and the straight-to-the bone sonics of the Big Four of thrash metal, the group�s idiosyncratic sound is as unique as their batshit, DIY-or-die approach to the visual side of the group (when they�ve got nothing band-wise to create, they make viral memes - you may have seen their Matrix-referencing take on England�s World Cup prospects�) It�s a mixing pot of the trio�s collective interests and ambitions - a fact that sees Will and Billy produce, directi, shoot, and edit all the band�s videos merch designs and even album art - and one that hides a dark, occult-esque heart under its catchy melodies and scream-along, festival-ready choruses.<br /><br />�We had a bit of a wake-up moment,� Jock admits of that more conventional, pre-Puppy past, �and we just thought, �Why are we doing stuff that everyone else is doing, without questioning it?� From there on out, it was individuality, all the way. �That song, �Forever�, has about fifty guitars all layered up,� he laughs of their early attempts to inject some bonkers into the mix. �We wanted to make more of a celebration and an identity out of our differences, rather than the common threads.� Above all, though, they just wanted to create something fucking fun, channeling the assuredness of those yesteryear rockstars into something that eschewed pretension, without ever dipping into pantomime or parody. That approach has seeped into every crack of The Goat - a record that�ll inspire grins from even the most grizzled metalheads, and headbanging from the most hesitant indie kids. �That�s been the mantra of the band, from then � even though the sound�s developed, we�ve kept that mentality of wanting to constantly push ourselves and keep chasing and exploring what seems cool to us,� says Jock.<br /><br />It�s an approach which initially had its pitfalls, Jock admits � while they were more confident than ever in the music they were making, the fact they didn�t fit in a box made finding their feet all the more challenging. �We were always the lightest band on a heavier bill, or the heaviest band on a lighter bill,� he says - occupying a middle ground between the worlds of indie, rock and metal meant finding gig line-ups they could jump on was a Herculean task. Through sheer resilience, self-belief and the storming Vol. 2 EP though, they soon found themselves climbing the ranks of rock royalty. An appearance on Guitar Hero for �Forever� led straight into a packed-out slot at Download Festival 2016 � a festival they were told early on was out of their reach. The following year, they played Glastonbury; soon after that, Bloodstock - a festival double-header that few bands could manage to pull off. A similar eclecticism was exhibited on their choice of tours, which saw them share bills with everyone from glam-punks Creeper, to doom metallers Conan and skater boy icons CKY in those early years. All the while, they collected praise from the likes of The Guardian, Radio 1, Noisey, Kerrang!, DIY, Rock Sound, and more. Their mounting success was evidence that their dedication wasn�t misplaced - following their own path found Puppy a fervent, diverse fanbase. �I don�t think we were sure if we�d get accepted by the rock-ier worlds,� Jock admits - �When you�re not playing those shows, you imagine guys in bullet belts and leather vest with their arms folded, just shaking their heads!�<br /> <br />The Goat has plenty to offer everyone � from bullet-belted metalheads to shoegazing fuzz lovers, it�s a record that thrives off its kaleidoscopic approach to creativity and the band�s mischievous mentality. Beginning the process of piecing together The Goat early last year, their plan was simple � �to keep that initial mindset at the forefront,� says Jock, �to do stuff that really excited us.� Entering the studio in the summer of 2017, they leapfrogged every expectation from the off. �I think the songs on the new album are the best songs we�ve written across the board,� he admits. �As much as you can explore new influences, and new sounds, and new textures � at the end of the day, the songs have gotta bang!� It�s a record that, as a result, has no clear pinnacle � every song has been fine-tuned to its most hard-hitting form. �For me, the big thing was to be able to take any song from the album and be happy for that to be the only song of ours that someone heard,� he says of the all-killer-no-filler approach that propelled The Goat.<br /><br />From the guttural stomp of lead single �Black Hole�, via the theatrics of �Nightwalker� and �World Stands Still��s action-movie-montage-ready pomp, no stone is left unturned in Puppy�s desire to push boundaries and � above all � embrace the fun inherent in rock�s former heyday. Jock cites a suitable mish-mash of influences on that mindset � everyone from the aforementioned Black Sabbath and Weezer, to Helmet, Faith No More and Teenage Fanclub got a look in when they were growing up. For the group that would one day become Puppy, Jock admits, there was no tribalism. �Obviously we could tell that one guy�s jeans were a lot baggier than the others�, but generally speaking it was all just guitar music!� he says with a laugh. <br /> <br />That freed-up feeling flows throughout The Goat. A record that dodges convention and pretension at every turn in favour of a fun-first approach, it�s one of the year�s finest guitar albums, from one of the country�s most entrancing new bands.</p>
+        
+                <div class="addthis_inline_share_toolbox"></div>
+                <div class="VariantAlert"></div>
+            </div>
+            
+            
+            <div class="block-group neutral-filled padded section-margins">
+                <h4>Tickets</h4>
+            </div>
+        
+            <div class="block-group block-group-flex">
+                <form method="post" action="https://www.wegottickets.com/action" class="full-width">
+                    <input type="hidden" name="action" value="basket" />
+                    <input type="hidden" name="type" value="addmany" />
+                    
+            <div class="BuyBox block">
+                <h2>General Admission</h2>
+                
+                <table class="full-width">
+                    <tbody>
+                        <tr>
+                            <td class="half text-top">
+                                <p>25 tickets available</p>
+                                <p>14 and over</p>
+                            </td>
+                            <td class="half text-top text-right">
+                                <p>&pound;10.00 + &pound;1.00 Booking fee = <strong>&pound;11.00</strong></p>
+                                
+            <input type="hidden" name="variantId[]" value="461540" />
+        
+            <button name="buy" class="right button">Buy</button>
+            <button name="+" class="right button" style="display: none;"></button>
+        
+            <input
+                type="number"
+                name="qty[]"
+                title="quantity"
+                value="0"
+                class="right"
+                min="0"
+                max="25"
+                step="1"
+                style="display: none;"
+            />
+        
+            <button name="-" class="right button" style="display: none;"></button>
+        
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        
+                    <input type="submit" value="Proceed" class="proceed margin-top advance-filled-icon right desktop-third mobile-full-width" />
+                </form>
+            </div>
+        
+        </div>
+        
+                                
+        
+        <div>
+            
+            <ul></ul>
+        </div>
+        
+        <div class="EventLocation">
+            <div class="section-margins neutral-filled padded">
+                <h4>Venue Information</h4>
+            </div>
+            
+            <ul class="block-group clearfix">
+                <li class="diptych block">
+                    <p>
+                        <a href="https://www.wegottickets.com/location/563"><strong>LEEDS: The Brudenell Social Club</strong></a>
+                        <br/>
+                        33 Queens Road<br />Leeds<br />West Yorkshire<br />LS6 1NY<br /><br/>
+                        <br/>
+                        Live music will generally begin around 30 minutes after doors open.
+                    </p>
+                </li>
+                
+                <li class="diptych block">
+                    <p id="venueWebsite"><a href="http://www.brudenellsocialclub.co.uk" target="_blank">Website</a> &nbsp;</p>
+                    <p id="venueTelephone">01132752411 &nbsp;</p>
+                    <p><p id="StreetmapLink"><a id="StreetmapAnchor" href="http://www.streetmap.co.uk/streetmap.dll?G2M?X=428396&Y=434903&A=Y&Z=1" target="_blank">Map of the venue location (Streetmap)</a></p></p>
+                </li>
+            </ul>
+            
+            <div id="seatingPlan">
+                <div></div>
+            </div>
+        </div>
+        
+        <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4ee211b53db2f064"></script>
+        
+                            </div>
+                        </div>
+                        <div id="RightColumn">
+                            
+                            <div class="content padded filled chatterbox-margin">
+            <div class="panel-heading">
+                <h3 class="neutral">Simple, honest ticketing.</h3>
+            </div>
+            <div class="panel-body">
+                In the sometimes murky world of ticket sales, WeGotTickets are the box office the nation trusts to be the good
+                guys.
+                <ul class="values">
+                    <li class="cat-newsletter">
+                        <h4>Instant e-ticket delivery</h4>
+                        <p>Our tickets are delivered to your inbox, not by post.</p>
+                    </li>
+                    <li class="cat-fees">
+                        <h4>Affordable, transparent fees</h4>
+                        <p>We won't rip you off to line someone else's pockets.</p>
+                    </li>
+                    <li class="cat-custservice">
+                        <h4>Amazing customer service</h4>
+                        <p>Our support staff's award winning service won't let you down.</p>
+                    </li>
+                </ul>
+                <a href="/about"> Find out more about WeGotTickets and our values. </a>
+            </div>
+        </div>
+        <div class="mpu chatterbox-margin">
+            <a href="http://www.wegottickets.com/about"><img src="https://www.wegottickets.com/images/features/DYKadvocates1516033884.jpg" alt="" /></a>
+        </div>
+        <!-- /3595/uk_WeGotTickets -->
+        <div class="mpu mpu_placeholder chatterbox-margin">
+            <div id="mpu-ad-placeholder"></div>
+            <noscript>
+                <a href="http://blog.wegottickets.com/about-indie50/">
+                    <img src="https://www.wegottickets.com/images/rebrand/houseads/mpu_blog.png" alt="Read our Blog" />
+                </a>
+            </noscript>
+        </div>
+        <div class="mpu chatterbox-margin">
+            <a href="https://clients.wegottickets.com/?cc=fest-18"><img src="https://www.wegottickets.com/images/features/Festivals1506609669.jpg" alt="" /></a>
+        </div>
+        
+                        </div>
+                    </div>
+                </div>
+                <footer id="footer">
+                    <div class="medium-hidden">
+                        <div class="content">
+                            <div class="padded">
+                                <a href="#top" id="back-to-top" class="button highlight-filled full-width"
+                                title="Back to top"> Back to top </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="newsletter" class="small-hidden filled">
+                        <div class="content">
+                            <span class="icon"></span>
+                            <h4>Sign-up to our newsletter</h4>
+                            <form id="newsletter-signup" method="post" action="/mailing">
+                                <input type="text" name="ml_email" placeholder="Enter email address..."/>
+                                <input type="hidden" name="ml_region" value="0"/>
+                                <input type="hidden" name="ml_format" value="html"/>
+                                <input class="button neutral-filled" name="submit" type="submit" value="Sign-up"/>
+                            </form>
+                        </div>
+                    </div>
+                        
+                <div class="bottomboard mpu_placeholder">
+                    <div id="bottomboard-ad-placeholder"></div>
+                    <noscript>
+                        <a class="small-hidden" href="/about" title="About WeGotTickets">
+                            <img class="small-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/leaderboard_environment.png" alt="Our e-ticket systems emits 1000 times less carbon than postal tickets" />
+                        </a>
+                        <a class="medium-hidden" href="http://blog.wegottickets.com/about-indie50/">
+                            <img class="medium-hidden" src="https://www.wegottickets.com/images/rebrand/houseads/mobile_indie50.png" alt="WeGotTickets Indie50 blog" />
+                        </a>
+                    </noscript>
+                </div>
+                    <div class="social-icons filled">
+                        <a href="https://twitter.com/wegottickets">
+                            <img src="https://www.wegottickets.com/rebrand/images/icons/ico-twitter_32.png"
                                 alt="@WeGotTickets on Twitter" title="WeGotTickets on Twitter"/>
-                    </a>
-                    <a href="https://www.facebook.com/WeGotTickets-40707078898" name="WeGotTickets Facebook account">
-                        <img src="https://www.wegottickets.com/rebrand/images/icons/ico-facebook_32.png" name="WeGotTickets on Facebook"
+                        </a>
+                        <a href="https://www.facebook.com/WeGotTickets-40707078898">
+                            <img src="https://www.wegottickets.com/rebrand/images/icons/ico-facebook_32.png"
                                 alt="WeGotTickets on Facebook" title="WeGotTickets on Facebook"/>
-                    </a>
-                    <a href="https://www.instagram.com/wegottickets" name="WeGotTickets Instagram account">
-                        <img src="https://www.wegottickets.com/rebrand/images/icons/ico-instagram_32.png" name="WeGotTickets on Instagram"
+                        </a>
+                        <a href="https://www.instagram.com/wegottickets">
+                            <img src="https://www.wegottickets.com/rebrand/images/icons/ico-instagram_32.png"
                                 alt="WeGotTickets on Instagram" title="WeGotTickets on Instagram"/>
-                    </a>
-                </div>
-                <div id="footer-links">
-                    <div class="content block-group">
-                        <div class="block small-hidden padded links quadtych">
-                            <h4>About us</h4>
-                            <ul>
-                                <li><a title="About WeGotTickets"        href="/about"                           >About WeGotTickets</a></li>
-                                <li><a title="Environmental policy"      href="/about/environmentalpolicy"       >Environmental policy</a></li>
-                                <li><a title="Good causes"               href="/about/goodcauses"                >Good causes</a></li>
-                                <li><a title="Booking fees"              href="/about/bookingfees"               >Booking fees</a></li>
-                                <li><a title="Advertise on WeGotTickets" href="https://clients.wegottickets.com/i/wgt_advert_rate.pdf">Advertise on WeGotTickets</a></li>
-                            </ul>
-                        </div>
-                        <div class="block small-hidden padded links quadtych">
-                            <h4>Customer services</h4>
-                            <ul>
-                                <li><a title="Where are my tickets?"    href="/faqs/24#faq"                         >Where are my tickets?</a></li>
-                                <li><a title="My account"               href="/account"                         >My account</a></li>
-                                <li><a title="FAQs"                     href="/faqs"          class="list-group-item">FAQs</a></li>
-                                <li><a title="Terms & conditions"       href="/tandc"                                >Terms & conditions</a></li>
-                                <li><a title="Privacy policy"           href="/ppl"                                  >Privacy policy</a></li>
-                                <li><a title="Cookie policy"            href="/cookies"                              >Cookie policy</a></li>
-                                <li><a title="Contact us"               href="/contact"       class="list-group-item">Contact us</a></li>
-                            </ul>
-                        </div>
-                        <div class="block small-hidden padded links quadtych">
-                            <h4>Event organisers</h4>
-                            <ul>
-                                <li><a title="Log in to Client admin" href="https://clients.wegottickets.com/login.php"                       target="_blank">Log in to Client admin</a></li>
-                                <li><a title="Ticket your event"      href="https://clients.wegottickets.com/?cc=cs-footer"                   target="_blank">Ticket your event</a></li>
-                                <li><a title="Why sell through us?"   href="https://clients.wegottickets.com/?cc=cs-footer-why-sell#services" target="_blank">Why sell through us?</a></li>
-                                <li><a title="Become an affiliate"    href="https://clients.wegottickets.com/affiliates.php"                  target="_blank">Become an affiliate</a></li>
-                                <li><a title="Read our Blog"          href="https://blog.wegottickets.com/"                                   target="_blank">Read our Blog</a></li>
-                                <li><a title="INDIE50"                href="https://indie50.wordpress.com/" target="_blank">INDIE50</a></li>
-                            </ul>
-                        </div>
-                        <div class="block star links quadtych">
-                            <ul>
-                                <li>
-                                    <a title="STAR Authorised Seller" href="http://www.star.org.uk/starmembers/full-members/we-got-tickets"
+                        </a>
+                    </div>
+                    <div id="footer-links">
+                        <div class="content block-group">
+                            <div class="block small-hidden padded links quadtych">
+                                <h4>About us</h4>
+                                <ul>
+                                    <li><a title="About WeGotTickets"        href="/about"                           >About WeGotTickets</a></li>
+                                    <li><a title="Environmental policy"      href="/about/environmentalpolicy"       >Environmental policy</a></li>
+                                    <li><a title="Good causes"               href="/about/goodcauses"                >Good causes</a></li>
+                                    <li><a title="Booking fees"              href="/about/bookingfees"               >Booking fees</a></li>
+                                    <li><a title="Advertise on WeGotTickets" href="https://clients.wegottickets.com/i/wgt_advert_rate.pdf">Advertise on WeGotTickets</a></li>
+                                    <li><a title="Jobs"                      href="/jobs"                            >Jobs</a></li>
+                                </ul>
+                            </div>
+                            <div class="block small-hidden padded links quadtych">
+                                <h4>Customer services</h4>
+                                <ul>
+                                    <li><a title="Where are my tickets?"    href="/faqs/24#faq"                         >Where are my tickets?</a></li>
+                                    <li><a title="My account"               href="/account"                         >My account</a></li>
+                                    <li><a title="FAQs"                     href="/faqs"          class="list-group-item">FAQs</a></li>
+                                    <li><a title="Terms &amp; conditions"   href="/tandc"                                >Terms &amp; conditions</a></li>
+                                    <li><a title="Privacy policy"           href="/ppl"                                  >Privacy policy</a></li>
+                                    <li><a title="Cookie policy"            href="/cookies"                              >Cookie policy</a></li>
+                                    <li><a title="Contact us"               href="/contact"       class="list-group-item">Contact us</a></li>
+                                </ul>
+                            </div>
+                            <div class="block small-hidden padded links quadtych">
+                                <h4>Event organisers</h4>
+                                <ul>
+                                    <li><a title="Log in to Client admin" href="https://clients.wegottickets.com/login.php"                       target="_blank">Log in to Client admin</a></li>
+                                    <li><a title="Ticket your event"      href="https://clients.wegottickets.com/?cc=cs-footer"                   target="_blank">Ticket your event</a></li>
+                                    <li><a title="Why sell through us?"   href="https://clients.wegottickets.com/?cc=cs-footer-why-sell#services" target="_blank">Why sell through us?</a></li>
+                                    <li><a title="Become an affiliate"    href="https://clients.wegottickets.com/affiliates.php"                  target="_blank">Become an affiliate</a></li>
+                                    <li><a title="Read our Blog"          href="https://blog.wegottickets.com/"                                   target="_blank">Read our Blog</a></li>
+                                    <li><a title="INDIE50"                href="https://indie50.wordpress.com/" target="_blank">INDIE50</a></li>
+                                </ul>
+                            </div>
+                            <div class="block star links quadtych">
+                                <ul>
+                                    <li>
+                                        <a title="STAR Authorised Seller" href="http://www.star.org.uk/starmembers/full-members/we-got-tickets"
                                         class="fancybox fancybox.iframe star-compliance">
-                                        <img src="https://www.wegottickets.com/rebrand/images/star_verification.png"
-                                                alt="STAR Authorised Seller">
-                                    </a>
-                                </li>
-                                <li>
-                                    <a title="Secure payments by Sagepay" href="http://www.sagepay.co.uk/" target="_blank">
-                                        <img src="https://www.wegottickets.com/rebrand/images/sagepay.png" alt="Secure payments by Sagepay">
-                                    </a>
-                                </li>
-                            </ul>
+                                            <img src="https://www.wegottickets.com/rebrand/images/star_verification.png" alt="STAR Authorised Seller" />
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a title="Secure payments by Sagepay" href="http://www.sagepay.co.uk/" target="_blank">
+                                            <img src="https://www.wegottickets.com/rebrand/images/sagepay.png" alt="Secure payments by Sagepay" />
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="content block-group">
+                            <div class="block padded footer-copyright">
+                                &copy; Internet Tickets Ltd 2019
+                            </div>
                         </div>
                     </div>
-                    <div class="content block-group">
-                        <div class="block padded footer-copyright">
-                            &copy; Internet Tickets Ltd 2018
-                        </div>
-                    </div>
-                </div>
-            </footer>
-            <script type='text/javascript'>var fc_CSS=document.createElement('link');fc_CSS.setAttribute('rel','stylesheet');var fc_isSecured = (window.location && window.location.protocol == 'https:');var fc_lang = document.getElementsByTagName('html')[0].getAttribute('lang'); var fc_rtlLanguages = ['ar','he']; var fc_rtlSuffix = (fc_rtlLanguages.indexOf(fc_lang) >= 0) ? '-rtl' : '';fc_CSS.setAttribute('type','text/css');fc_CSS.setAttribute('href',((fc_isSecured)? 'https://d36mpcpuzc4ztk.cloudfront.net':'http://assets1.chat.freshdesk.com')+'/css/visitor'+fc_rtlSuffix+'.css');document.getElementsByTagName('head')[0].appendChild(fc_CSS);var fc_JS=document.createElement('script'); fc_JS.type='text/javascript'; fc_JS.defer=true;fc_JS.src=((fc_isSecured)?'https://d36mpcpuzc4ztk.cloudfront.net':'http://assets.chat.freshdesk.com')+'/js/visitor.js';(document.body?document.body:document.getElementsByTagName('head')[0]).appendChild(fc_JS);window.livechat_setting= 'eyJ3aWRnZXRfc2l0ZV91cmwiOiJ3ZWdvdHRpY2tldHMuZnJlc2hkZXNrLmNvbSIsInByb2R1Y3RfaWQiOm51bGwsIm5hbWUiOiJXZUdvdFRpY2tldHMiLCJ3aWRnZXRfZXh0ZXJuYWxfaWQiOm51bGwsIndpZGdldF9pZCI6ImJlZjMwYjIyLWQ1NTItNGUyNS05YzUyLWJhOTVmNjZhMTI0ZCIsInNob3dfb25fcG9ydGFsIjpmYWxzZSwicG9ydGFsX2xvZ2luX3JlcXVpcmVkIjpmYWxzZSwibGFuZ3VhZ2UiOiJlbiIsInRpbWV6b25lIjoiTG9uZG9uIiwiaWQiOjE3MDAwMDAyNDg2LCJtYWluX3dpZGdldCI6MSwiZmNfaWQiOiJkZGRhZWI2ZWUzOWY5YjdiOTIxOGU1YWM0YmJjZTEzZSIsInNob3ciOjEsInJlcXVpcmVkIjoyLCJoZWxwZGVza25hbWUiOiJXZUdvdFRpY2tldHMiLCJuYW1lX2xhYmVsIjoiTmFtZSIsIm1lc3NhZ2VfbGFiZWwiOiJNZXNzYWdlIiwicGhvbmVfbGFiZWwiOiJQaG9uZSIsInRleHRmaWVsZF9sYWJlbCI6IlRleHRmaWVsZCIsImRyb3Bkb3duX2xhYmVsIjoiRHJvcGRvd24iLCJ3ZWJ1cmwiOiJ3ZWdvdHRpY2tldHMuZnJlc2hkZXNrLmNvbSIsIm5vZGV1cmwiOiJjaGF0LmZyZXNoZGVzay5jb20iLCJkZWJ1ZyI6MSwibWUiOiJNZSIsImV4cGlyeSI6MCwiZW52aXJvbm1lbnQiOiJwcm9kdWN0aW9uIiwiZW5kX2NoYXRfdGhhbmtfbXNnIjoiVGhhbmsgeW91ISEhIiwiZW5kX2NoYXRfZW5kX3RpdGxlIjoiRW5kIiwiZW5kX2NoYXRfY2FuY2VsX3RpdGxlIjoiQ2FuY2VsIiwic2l0ZV9pZCI6ImRkZGFlYjZlZTM5ZjliN2I5MjE4ZTVhYzRiYmNlMTNlIiwiYWN0aXZlIjoxLCJyb3V0aW5nIjp7ImNob2ljZXMiOnsiSSB3YW50IHRvIGJ1eSB0aWNrZXRzLiI6WyIwIl0sIkkgYWxyZWFkeSBoYXZlIHRpY2tldHMuIjpbIjAiXSwiSSdtIGFuIGV2ZW50IG9yZ2FuaXNlci4iOlsiMCJdLCJTb21ldGhpbmcgZWxzZS4iOlsiMCJdLCJkZWZhdWx0IjpbIjAiXX0sImRyb3Bkb3duX2Jhc2VkIjoiZmFsc2UifSwicHJlY2hhdF9mb3JtIjoxLCJidXNpbmVzc19jYWxlbmRhciI6bnVsbCwicHJvYWN0aXZlX2NoYXQiOjAsInByb2FjdGl2ZV90aW1lIjoxMDUsInNpdGVfdXJsIjoid2Vnb3R0aWNrZXRzLmZyZXNoZGVzay5jb20iLCJleHRlcm5hbF9pZCI6bnVsbCwiZGVsZXRlZCI6MCwibW9iaWxlIjoxLCJhY2NvdW50X2lkIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNy0wMS0wN1QxMDo1NzowMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTctMDItMDdUMTM6NDM6MTcuMDAwWiIsImNiRGVmYXVsdE1lc3NhZ2VzIjp7ImNvYnJvd3Npbmdfc3RhcnRfbXNnIjoiWW91ciBzY3JlZW5zaGFyZSBzZXNzaW9uIGhhcyBzdGFydGVkIiwiY29icm93c2luZ19zdG9wX21zZyI6IllvdXIgc2NyZWVuc2hhcmluZyBzZXNzaW9uIGhhcyBlbmRlZCIsImNvYnJvd3NpbmdfZGVueV9tc2ciOiJZb3VyIHJlcXVlc3Qgd2FzIGRlY2xpbmVkIiwiY29icm93c2luZ19hZ2VudF9idXN5IjoiQWdlbnQgaXMgaW4gc2NyZWVuIHNoYXJlIHNlc3Npb24gd2l0aCBjdXN0b21lciIsImNvYnJvd3Npbmdfdmlld2luZ19zY3JlZW4iOiJZb3UgYXJlIHZpZXdpbmcgdGhlIHZpc2l0b3LigJlzIHNjcmVlbiIsImNvYnJvd3NpbmdfY29udHJvbGxpbmdfc2NyZWVuIjoiWW91IGhhdmUgYWNjZXNzIHRvIHZpc2l0b3LigJlzIHNjcmVlbi4iLCJjb2Jyb3dzaW5nX3JlcXVlc3RfY29udHJvbCI6IlJlcXVlc3QgdmlzaXRvciBmb3Igc2NyZWVuIGFjY2VzcyAiLCJjb2Jyb3dzaW5nX2dpdmVfdmlzaXRvcl9jb250cm9sIjoiR2l2ZSBhY2Nlc3MgYmFjayB0byB2aXNpdG9yICIsImNvYnJvd3Npbmdfc3RvcF9yZXF1ZXN0IjoiRW5kIHlvdXIgc2NyZWVuc2hhcmluZyBzZXNzaW9uICIsImNvYnJvd3NpbmdfcmVxdWVzdF9jb250cm9sX3JlamVjdGVkIjoiWW91ciByZXF1ZXN0IHdhcyBkZWNsaW5lZCAiLCJjb2Jyb3dzaW5nX2NhbmNlbF92aXNpdG9yX21zZyI6IlNjcmVlbnNoYXJpbmcgaXMgY3VycmVudGx5IHVuYXZhaWxhYmxlICIsImNvYnJvd3NpbmdfYWdlbnRfcmVxdWVzdF9jb250cm9sIjoiQWdlbnQgaXMgcmVxdWVzdGluZyBhY2Nlc3MgdG8geW91ciBzY3JlZW4gIiwiY2Jfdmlld2luZ19zY3JlZW5fdmkiOiJBZ2VudCBjYW4gdmlldyB5b3VyIHNjcmVlbiAiLCJjYl9jb250cm9sbGluZ19zY3JlZW5fdmkiOiJBZ2VudCBoYXMgYWNjZXNzIHRvIHlvdXIgc2NyZWVuICIsImNiX3ZpZXdfbW9kZV9zdWJ0ZXh0IjoiWW91ciBhY2Nlc3MgdG8gdGhlIHNjcmVlbiBoYXMgYmVlbiB3aXRoZHJhd24gIiwiY2JfZ2l2ZV9jb250cm9sX3ZpIjoiQWxsb3cgYWdlbnQgdG8gYWNjZXNzIHlvdXIgc2NyZWVuICIsImNiX3Zpc2l0b3Jfc2Vzc2lvbl9yZXF1ZXN0IjoiQWdlbnQgc2Vla3MgYWNjZXNzIHRvIHlvdXIgc2NyZWVuICJ9fQ==';</script>
-        </body>
-        </html>
+                </footer>
+                
+            </body>
+        </html>    
     `
 }


### PR DESCRIPTION
* Change outdated, incorrect music event fixture

* Fix scraping of event date and time - could not accurately test random whitespace for result of #findDateAndTime. Therefore returns an array instead with whitespace trimmed, to be formatted later.

* Add missing semicolons for function expressions